### PR TITLE
Add requirements file and clean up runtime installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# TT Learning Effect
+
+## Setup
+
+```bash
+pip install -r requirements.txt
+```
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+customtkinter
+pandas
+numpy
+scipy
+xlsxwriter
+openpyxl

--- a/src/LearningEffectAnalysis.py
+++ b/src/LearningEffectAnalysis.py
@@ -29,22 +29,6 @@ import sys
 import tkinter
 import re
 
-required_packages = [
-    'customtkinter',
-    'pandas',
-    'numpy',
-    'scipy',
-    'xlsxwriter'
-    'openpyxl',  # For reading/writing Excel files
-]
-
-for pkg in required_packages:
-    try:
-        importlib.import_module(pkg)
-    except ImportError:
-        print(f"Installing missing package: {pkg}")
-        subprocess.check_call([sys.executable, '-m', 'pip', 'install', pkg])
-
 # =============================================================================
 # SECTION 2: IMPORTS
 # =============================================================================


### PR DESCRIPTION
## Summary
- remove automatic runtime installation from `LearningEffectAnalysis`
- list python packages in `requirements.txt`
- document setup in a new root README

## Testing
- `python3 -m py_compile src/LearningEffectAnalysis.py`

------
https://chatgpt.com/codex/tasks/task_e_686545a4445c832ca1d2e6a275d50c70