### PR TITLE
Remove unused imports in LearningEffectAnalysis

### DIFF
--- a/src/LearningEffectAnalysis.py
+++ b/src/LearningEffectAnalysis.py
@@ -23,9 +23,6 @@ The application performs the following key operations:
 # =============================================================================
 # SECTION 1: DEPENDENCY MANAGEMENT
 # =============================================================================
-import importlib
-import subprocess
-import sys
 import tkinter
 import re
 


### PR DESCRIPTION
## Summary
- drop unused modules from LearningEffectAnalysis

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686555476934832c9105a9ed3fb1d6bc