### PR TITLE
Remove log fade animation

### DIFF
--- a/src/LearningEffectAnalysis.py
+++ b/src/LearningEffectAnalysis.py
@@ -125,12 +125,9 @@ class TrialAnalyzerApp(ctk.CTk):
         anim.fade_window(self, update_widgets)
 
     def _log(self, message: str) -> None:
-        """Append a timestamped message to the log textbox."""
-        tag = f"line_{self.log_box.index('end')}"
-        self.log_box.insert("end", message + "\n", tag)
-
+        """Append a message to the log textbox."""
+        self.log_box.insert("end", message + "\n")
         self.log_box.see("end")
-        anim.fade_log(self.log_box, tag)
 
     def browse_data_folder(self) -> None:
         """Prompt the user to select the root directory containing trial data."""

--- a/src/gui_animations.py
+++ b/src/gui_animations.py
@@ -31,17 +31,6 @@ def pulse(widget: ctk.CTkBaseClass, color: str = "#90C2FF", duration: int = 200)
     widget.after(duration, lambda: widget.configure(fg_color=orig))
 
 
-def fade_log(textbox: ctk.CTkTextbox, tag: str, steps: int = 10, delay: int = 50) -> None:
-    """Fade a tagged log line from gray to black to draw attention."""
-    def step(i: int) -> None:
-        level = 55 + int((200 / steps) * i)
-        color = f"#{level:02x}{level:02x}{level:02x}"
-        textbox.tag_config(tag, foreground=color)
-        if i < steps:
-            textbox.after(delay, step, i + 1)
-    step(0)
-
-
 def slide_window(win: ctk.CTkToplevel, end_y: int, step: int = 10, delay: int = 10) -> None:
     """Animate a toplevel window sliding down from the top."""
     x = win.winfo_x()


### PR DESCRIPTION
## Summary
- simplify logging logic
- remove obsolete `fade_log` animation

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686562b5c228832cbadb1ba2723a05f9